### PR TITLE
Update dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ BackBLAST_Reciprocal_BLAST
 ==========================
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.3465955.svg)](https://doi.org/10.5281/zenodo.3465955)
 
-Copyright Lee H. Bergstrand and Jackson M. Tsuji, 2021
+Copyright Lee H. Bergstrand and Jackson M. Tsuji, 2022
 
 # Software overview
 (To be updated once BackBLAST2 is complete)

--- a/backblast
+++ b/backblast
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 # BackBLAST
-# Copyright Lee H. Bergstrand and Jackson M. Tsuji, 2021
+# Copyright Lee H. Bergstrand and Jackson M. Tsuji, 2022
 # The entry script for running BackBLAST via command line
 
 # GLOBAL variables
-readonly VERSION="2.0.0-alpha5"
+readonly VERSION="2.0.0-alpha6"
 readonly SCRIPT_NAME="${0##*/}"
 readonly SCRIPT_DIR="$(realpath ${0%/*})"
 readonly UTILS_DIR="${SCRIPT_DIR}/scripts"

--- a/backblast
+++ b/backblast
@@ -6,6 +6,7 @@ set -euo pipefail
 
 # GLOBAL variables
 readonly VERSION="2.0.0-alpha6"
+readonly COPYRIGHT_YEAR="2022"
 readonly SCRIPT_NAME="${0##*/}"
 readonly SCRIPT_DIR="$(realpath ${0%/*})"
 readonly UTILS_DIR="${SCRIPT_DIR}/scripts"
@@ -518,7 +519,7 @@ function main() {
 
     # Help statement
     printf "${SCRIPT_NAME}: pipeline to search for and visualize gene homologs across multiple genomes.\n"
-    printf "Copyright Lee H. Bergstrand and Jackson M. Tsuji, Neufeld Research Group, 2019\n"
+    printf "Copyright Lee H. Bergstrand and Jackson M. Tsuji, Neufeld Research Group, ${COPYRIGHT_YEAR}\n"
     printf "Version: ${VERSION}\n\n"
     printf "Please specify a run mode for the main workflow for further usage instructions:\n"
     printf "   1. setup: for setting up pre-run configuration files\n"

--- a/envs/conda_requirements.yaml
+++ b/envs/conda_requirements.yaml
@@ -5,7 +5,7 @@ channels:
   - defaults
 dependencies:
   - python=3.9
-  - snakemake=6
+  - snakemake=7
   - biopython>=1.76,<=1.79
   - blast>=2.9,<=2.13
   - r-base=4

--- a/envs/conda_requirements.yaml
+++ b/envs/conda_requirements.yaml
@@ -1,14 +1,14 @@
 channels:
-  - r
   - conda-forge
   - bioconda
+  - r
   - defaults
 dependencies:
   - python=3.9
   - snakemake=6
   - biopython>=1.76,<=1.79
-  - blast>=2.9,<=2.12
-  - r-base>=4.0,<=4.2
+  - blast>=2.9,<=2.13
+  - r-base=4
   - r-codetools
   - r-conflicted
   - r-getopt=1.20
@@ -16,16 +16,16 @@ dependencies:
   - r-futile.logger=1.4
   - r-glue=1
   - r-plyr=1.8
-  - r-dplyr>=1.0.5,<=1.0.7
+  - r-dplyr=1.0
   - r-tibble=3.1
   - r-reshape2=1.4
   - r-rcolorbrewer=1.1_2
   - r-ggplot2=3
-  - r-ape>=5.3,<=5.5
+  - r-ape=5.6
   - r-maps=3.3
   - r-phytools>=0.6_99,<=0.7_80
-  - r-tidytree=0.3
-  - bioconductor-treeio>=1.10,<=1.17
-  - bioconductor-ggtree=3.0
+  - r-tidytree=0.4
+  - bioconductor-treeio=1.18
+  - bioconductor-ggtree=3.2
   - r-gridextra=2.3
   - r-egg=0.4

--- a/envs/gtotree.yaml
+++ b/envs/gtotree.yaml
@@ -4,4 +4,4 @@ channels:
   - astrobiomike
   - defaults
 dependencies:
-  - gtotree=1.6
+  - gtotree=1.7

--- a/scripts/combine_tables.R
+++ b/scripts/combine_tables.R
@@ -1,7 +1,7 @@
 #!/usr/bin/env Rscript
 
 # combine_tables.R
-# Copyright Lee H. Bergstrand and Jackson M. Tsuji, 2019
+# Copyright Lee H. Bergstrand and Jackson M. Tsuji, 2022
 # Combines BLAST output (CSV) tables into a single output table with headers
 # Part of the BackBLAST pipeline
 

--- a/scripts/create_blank_results.py
+++ b/scripts/create_blank_results.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # -----------------------------------------------------------------------------------------------------------
-# Copyright: Lee H. Bergstrand and Jackson M. Tsuji (2019)
+# Copyright: Lee H. Bergstrand and Jackson M. Tsuji (2022)
 # Description: A simple program that takes a FASTA file query and makes a csv of blank BLAST results. Part of the BackBLAST pipeline.
 #
 # Requirements: - This script requires the Biopython module: http://biopython.org/wiki/Download

--- a/scripts/generate_heatmap.R
+++ b/scripts/generate_heatmap.R
@@ -1,6 +1,6 @@
 #!/usr/bin/env Rscript
 # generate_heatmap.R
-# Copyright Lee H. Bergstrand and Jackson M. Tsuji, 2021
+# Copyright Lee H. Bergstrand and Jackson M. Tsuji, 2022
 # Plots a newick treefile and BLAST table together as a phylogenetic tree and heatmap
 # Part of the BackBLAST pipeline
 

--- a/scripts/generate_run_templates.sh
+++ b/scripts/generate_run_templates.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 # generate_run_templates.sh
-# Copyright Lee H. Bergstrand and Jackson M. Tsuji, 2019
+# Copyright Lee H. Bergstrand and Jackson M. Tsuji, 2022
 # Script for generating and manipulating BackBLAST config templates
 # Part of the BackBLAST pipeline
 

--- a/scripts/remove_duplicates.sh
+++ b/scripts/remove_duplicates.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 # remove_duplicates.sh
-# Copyright Lee H. Bergstrand and Jackson M. Tsuji, 2019
+# Copyright Lee H. Bergstrand and Jackson M. Tsuji, 2022
 # A simple script that removes multiple hits from BackBLAST results
 # Part of the BackBLAST pipeline
 

--- a/scripts/search.py
+++ b/scripts/search.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # ----------------------------------------------------------------------------------------
-# Copyright: Lee H. Bergstrand (2019)
+# Copyright: Lee H. Bergstrand (2022)
 # Description: A Biopython program that takes a list of query proteins and uses local BLASTP to search
 #              for highly similar proteins within a local blast database (usually a local db of a target
 #              proteome). The program then BLASTPs backwards from the found subject proteins to the query

--- a/snakemake/Snakefile
+++ b/snakemake/Snakefile
@@ -1,11 +1,11 @@
 # Snakemake rules for the BackBLAST pipeline
-# Copyright Lee H. Bergstrand and Jackson M. Tsuji, 2019
+# Copyright Lee H. Bergstrand and Jackson M. Tsuji, 2022
 
 import os
 from snakemake.utils import logger, min_version, update_config
 
 # Specify the minimum snakemake version allowable
-min_version("5.0")
+min_version("6.0")
 # Specify shell parameters
 shell.executable("/bin/bash")
 shell.prefix("set -o pipefail; ")


### PR DESCRIPTION
This PR updates several dependency versions so that BackBLAST can run in 2022. The updated code passes the basic end-to-end test (shown in the [README](https://github.com/LeeBergstrand/BackBLAST_Reciprocal_BLAST/blob/v2.0.0-alpha5/README.md#test-data)) on a Linux server running Ubuntu 20.04.3 LTS.

As I've indicated in the commit, if this code merges to `develop`, I'd like to push it to pre-release version `2.0.0-alpha6`. What do you think @LeeBergstrand ? Thanks.