### PR TITLE
Change HMM set name

### DIFF
--- a/snakemake/Snakefile
+++ b/snakemake/Snakefile
@@ -133,7 +133,7 @@ if config.get("phylogenetic_tree_newick") == "subjects":
             "logging/benchmarks/gtotree.benchmark.txt"
         threads: config.get("threads", 1)
         params:
-            phylogenetic_model = config.get("gtotree_phylogenetic_model", "Universal_Hug_et_al.hmm"),
+            phylogenetic_model = config.get("gtotree_phylogenetic_model", "Universal-Hug-et-al"),
             sequence_length_threshold = config.get("gtotree_sequence_length_threshold", "0.2"),
             minimum_hit_fraction = config.get("gtotree_minimum_hit_fraction", "0.5")
         shell:

--- a/snakemake/template_config.yaml
+++ b/snakemake/template_config.yaml
@@ -21,7 +21,7 @@ root_name: NA
 ## Options for GToTree, if you want to generate the phylogenetic tree within the BackBLAST pipeline
 ## For these options to be used, set 'phylogenetic_tree_newick' above to 'subjects'
 # Gene marker set to use for making the tree
-gtotree_phylogenetic_model: "Universal_Hug_et_al.hmm"
+gtotree_phylogenetic_model: "Universal-Hug-et-al"
 # Keeps gene hits within this proportional threshold of the median sequence length
 gtotree_sequence_length_threshold: 0.2
 # Keeps genomes with this proportion of hits from the gene marker set


### PR DESCRIPTION
GToTree updated the name of the Hug et. al. HMM set to use dashes instead of underscores in version 1.8.7, as shown in [this commit](https://github.com/AstrobioMike/GToTree/commit/39ce5f114391938612df1df49ee6cc759208bed9). I've provided a small patch that changes the name of that HMM set used by BackBLAST to match the new requirements. This fixes an error my colleague identified when using BackBLAST.

@LeeBergstrand Mind providing your feedback before I merge this? Thanks.
